### PR TITLE
Update gupfile-upload-to-sharepoint.js

### DIFF
--- a/gulp-tasks/upload-to-sharepoint/gupfile-upload-to-sharepoint.js
+++ b/gulp-tasks/upload-to-sharepoint/gupfile-upload-to-sharepoint.js
@@ -22,7 +22,7 @@ build.task('upload-to-sharepoint', {
 
     return new Promise((resolve, reject) => {
       const deployFolder = require('./config/copy-assets.json');
-      const folderLocation = `./${deployFolder.deployCdnPath}/**/*.js`;
+      const folderLocation = `./${deployFolder.deployCdnPath}/**/*.*`;
 
       return gulp.src(folderLocation)
         .pipe(spsync({


### PR DESCRIPTION
Allow all assets to be uploaded, not only .js files