### PR TITLE
Revert "Bump ua-parser-js from 0.7.20 to 0.7.28 in /samples/azure-devops-ci-cd-spfx"

### DIFF
--- a/samples/azure-devops-ci-cd-spfx/package-lock.json
+++ b/samples/azure-devops-ci-cd-spfx/package-lock.json
@@ -22553,9 +22553,9 @@
       "dev": true
     },
     "ua-parser-js": {
-      "version": "0.7.28",
-      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.28.tgz",
-      "integrity": "sha512-6Gurc1n//gjp9eQNXjD9O3M/sMwVtN5S8Lv9bvOYBfKfDNiIIhqiyi01vMBO45u4zkDE420w/e0se7Vs+sIg+g==",
+      "version": "0.7.20",
+      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.20.tgz",
+      "integrity": "sha512-8OaIKfzL5cpx8eCMAhhvTlft8GYF8b2eQr6JkCyVdrgjcytyOmPCXrqXFcUnhonRpLlh5yxEZVohm6mzaowUOw==",
       "dev": true
     },
     "uglify-js": {


### PR DESCRIPTION
Reverts pnp/sp-dev-build-extensions#51